### PR TITLE
HDOP inclusion tweaks for GPS and working TTNMapper examples

### DIFF
--- a/Files.md
+++ b/Files.md
@@ -38,6 +38,18 @@ The gwcnt indicates how many gateways picked up your transmission and is nice to
 
 It is also possible the server sends a status request MAC command after joining. The dragino code will handle that and add it's reply to the list of replies to be sent. If that has happened it should appear in the testMAC.log file.
 
+## gps_lpp.py
+
+A transmitter of the GPS Co-Ordinates in Cayenne LLP compliant format to TTN containing Latitude, Longtitude and Altitude values. Compatible with TTNMapper however not preferred as missing accuracy reference like HDOP, Satellites etc. Requires webhooks TTNMapper integration and selection of CayenneLLP standard decoder in TTN platform.
+
+## gps_ttnmapper.py
+
+A transmitter of more detailed GPS Co-Ordinates in TTNMapper compliant format to TTN containing Latitude, Longtitude, Altitude and HDOP (Horizontal Dilution of Precision) values. Requires within TTN use of the include javascript decoder and enablement of the webhooks TTNMapper integration. This is preferred as includes accuracy reference HDOP.
+
+## TTNv3Custom_decoder.js
+
+A javascript payload decoder to suit the gps_ttnmapper.py to process the received packet and present Latitude, Longitude, Altitude and HDOP values.
+
 # dragino folder
 
 ##/_/_init/_/_.py

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This has been heavily modified to :-
 * Changed user configuration file to TOML format
 * Cache all TTN parameters
 * Added flags to indicate if the system is transmitting
+* Examples and necessary tweaks for CayenneLLP / TTNMapper compliant gps co-ordinate transmission with SKY/HDOP (Horizontal Dilution of Precision) objects added.
 * added methods to get the last transmit air-time so that adherence to the LoRa duty cycle can be controlled
 
 TODO

--- a/TTNv3Custom_decoder.js
+++ b/TTNv3Custom_decoder.js
@@ -1,0 +1,54 @@
+function Decoder(bytes, port) {
+  // Decode an uplink message from a buffer
+  // (array) of bytes to an object of fields.
+  var decoded = {};
+
+  // if (port === 1) decoded.led = bytes[0];
+  decoded.lat = ((bytes[0]<<16)>>>0) + ((bytes[1]<<8)>>>0) + bytes[2];
+  decoded.lat = (decoded.lat / 16777215.0 * 180) - 90;
+  
+  decoded.lon = ((bytes[3]<<16)>>>0) + ((bytes[4]<<8)>>>0) + bytes[5];
+  decoded.lon = (decoded.lon / 16777215.0 * 360) - 180;
+  
+  var altValue = ((bytes[6]<<8)>>>0) + bytes[7];
+  var sign = bytes[6] & (1 << 7);
+  if(sign)
+  {
+    decoded.alt = 0xFFFF0000 | altValue;
+  }
+  else
+  {
+    decoded.alt = altValue;
+  }
+  
+  decoded.hdop = bytes[8] / 10.0;
+
+  return decoded;
+}
+function decodeUplink(input) {
+  var data = input.bytes;
+  var valid = true;
+
+  if (typeof Decoder === "function") {
+    data = Decoder(data, input.fPort);
+  }
+
+  if (typeof Converter === "function") {
+    data = Converter(data, input.fPort);
+  }
+
+  if (typeof Validator === "function") {
+    valid = Validator(data, input.fPort);
+  }
+
+  if (valid) {
+    return {
+      data: data
+    };
+  } else {
+    return {
+      data: {},
+      errors: ["Invalid data received"]
+    };
+  }
+}

--- a/dragino.toml
+++ b/dragino.toml
@@ -26,7 +26,8 @@
 	mac_cache="cache.json"
 	device_class="A"			# class B & C not yet supported
 
-	frequency_plan = "EU_863_870_TTN"
+	#frequency_plan = "EU_863_870_TTN"
+	frequency_plan = "AU_915_928_FSB_2"
 
 
 	# radio settings
@@ -50,13 +51,13 @@
 	# RX1 is normally the same as the uplink settings
 	# but can be changed by MAC commands
 	rx1_delay=5
-	rx1_DR=3
+	rx1_DR=11
 	
 	
 	# In EU RX2 is normally a fixed frequency & datarate
 	# but can be modified by MAC commands
-	rx2_DR=3
-	rx2_frequency=869.525
+	rx2_DR=11
+	rx2_frequency=923.3
 	rx2_delay=1				# follows from end of rx1_delay
 	
 	rx_window=1				# duration of receive windows

--- a/dragino/GPShandler.py
+++ b/dragino/GPShandler.py
@@ -30,6 +30,8 @@ class GPS:
 
         self.lat=None
         self.lon=None
+        self.alt=None
+        self.hdop=None
         self.timestamp=None
         self.lastGpsReading=None
 
@@ -75,8 +77,8 @@ class GPS:
             these values updated
 
         """
-        self.logger.debug(f"get_gps(): lat {self.lat}, lon {self.lon}, timestamp: {self.timestamp}")
-        return self.lat, self.lon, self.timestamp, self.lastGpsReading
+        self.logger.debug(f"get_gps(): lat {self.lat}, lon {self.lon}, alt {self.alt}, hdop {self.hdop}")
+        return self.lat, self.lon, self.alt, self.hdop
 
     def get_corrected_timestamp(self):
         """
@@ -171,7 +173,7 @@ class GPS:
 
                 # what follows will be deprecated
                 if data["class"] == "TPV":
-                    #print("TPV data",data)
+                #    print("TPV data",data)
                     if data["mode"]==0 or data["mode"]==1:
                         # no useable data or no fix
                         self.logger.info("No GPS fix (yet)")
@@ -180,11 +182,16 @@ class GPS:
                     try:
                         self.lat = data["lat"]
                         self.lon = data["lon"]
+                        self.alt = data["alt"]
                         self.timestamp = data["time"]
-                        #print(f"Got lat {self.lat} lon {self.lon}") 
+                        #print(f"Got lat {self.lat} lon {self.lon} alt {self.alt} at {self.timestamp}") 
                         self.lastGpsReading = time()
                     except KeyError as e:
                         self.logger.exception(f"unable to extract TPV data missing key error: {e}")
+                if data["class"] == "SKY":
+                    #print("SKY data",data)
+                    self.hdop = data["hdop"]
+                    print(f"Got lat {self.lat} lon {self.lon} alt {self.alt} hdop {self.hdop} at {self.timestamp}") 
                 else:
                     if VERBOSE:
                         self.logger.debug(f"GPS message was {data}")
@@ -210,11 +217,13 @@ if __name__=="__main__":
         while True:
 
             TPV=gps.getSentence("TPV")
+            SKY=gps.getSentence("SKY")
             if TPV is not None:
                 if nofix:
                     print("Got fix after",time()-start)
                     nofix=False
                     print("TPV:",TPV)
+                    print("SKY:",SKY)
 
             sleep(5)
     

--- a/dragino/dragino.py
+++ b/dragino/dragino.py
@@ -43,7 +43,7 @@ parentDir=os.path.dirname(currentDir)
 sys.path.append(parentDir)
 
 #################################
-DEFAULT_LOG_LEVEL = logging.DEBUG 	# Change after finishing development
+DEFAULT_LOG_LEVEL = logging.INFO 	# Change after finishing development
 DEFAULT_RETRIES = 3 				# How many attempts to send the message
 
 
@@ -67,7 +67,7 @@ class Dragino(LoRa):
     def __init__(
             self, config_filename,
             logging_level=DEFAULT_LOG_LEVEL,
-			enableGPS=False	
+			enableGPS=True
             ):
 
         self.confirmWithNextUplink=False # for confirmed data down

--- a/gps_lpp.py
+++ b/gps_lpp.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+    GPS location for dragino module - sends GPS sourced latitude, longitude & altitude out over LoRaWAN 50 times with 5 minutes intervals using CayenneLPP  
+    and FUTURE option to adhere to a 1% duty cycle
+
+    Note - observations are packets arrving at TTN are often concattonated - to be investigated. Results still seem to work and be correct. More testing required. - See TTNMapper alternative
+    Installation uses - 
+    wget https://github.com/FEEprojects/cayennelpp-python/releases/download/v1.0.0/simplecayennelpp-1.0.0.tar.gz
+    #install it
+    sudo pip3 install simplecayennelpp-1.0.0.tar.gz
+    Options to use other Cayenne LPP to be investigated
+
+    cache.json will be created if it doesn't exist
+"""
+import logging
+from datetime import datetime
+from time import sleep
+import RPi.GPIO as GPIO
+from dragino import Dragino
+from dragino.GPShandler import GPS
+from simplecayennelpp import CayenneLPP # import the module required to pack th -
+import binascii
+
+GPIO.setwarnings(False)
+
+gps=GPS()
+
+# add logfile
+#logLevel=logging.DEBUG
+logLevel=logging.INFO
+#logging.basicConfig(filename="gps.log", format='%(asctime)s - %(funcName)s - %(lineno)d - %(levelname)s - %(message)s', level=logLevel)
+
+# create a Dragino object and join to TTN
+D = Dragino("dragino.toml", logging_level=logLevel, enableGPS=True)
+D.join()
+
+print("Waiting for JOIN ACCEPT")
+while not D.registered():
+    print(".",end="")
+    sleep(2)
+print("\nJoined")
+
+while gps.lat is None:
+   sleep(1)
+lpp = CayenneLPP()
+
+for i in range(0, 50):
+    lpp.addGPS( 1, gps.lat, gps.lon, gps.alt)
+    text=binascii.hexlify(lpp.getBuffer()).decode()
+    sent=list(binascii.unhexlify(text))
+    D.send_bytes(sent)
+    print(text)
+    #print(sent)
+    print(gps.lat, gps.lon, gps.alt)
+    sleep(5)
+    start = datetime.utcnow()
+    while D.transmitting:
+        pass
+    end = datetime.utcnow()
+    print("Sent GPS Co-Ordinates (LPP) message ({})".format(end-start))
+    print(sent)
+    sleep(295)
+#    sleep(99*D.lastAirTime()) # limit to 1% duty cycle

--- a/gps_ttnmapper.py
+++ b/gps_ttnmapper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+    GPS location for dragino module - sends GPS sourced latitude, longitude, altitude & hdop out over LoRaWAN 50 times with 5 minute intervals  
+    and FUTURE to potentially adhere to a 1% duty cycle
+
+    cache.json will be created if it doesn't exist
+"""
+import logging
+from datetime import datetime
+from time import sleep
+import RPi.GPIO as GPIO
+from dragino import Dragino
+from dragino.GPShandler import GPS
+
+GPIO.setwarnings(False)
+
+gps=GPS()
+
+def convert_payload(lat, lon, alt, hdop):
+    """
+        Converts to the format used by ttnmapper.org - See webhook v3 intergration and use the included or reference javascript decoder
+        https://github.com/ttn-be/gps-node-examples/blob/master/Sodaq/sodaq-one-ttnmapper/decoder.js
+
+    """
+
+    payload = []
+    latb = int(((lat + 90) / 180) * 0xFFFFFF)
+    lonb = int(((lon + 180) / 360) * 0xFFFFFF)
+    altb = int(round(float(alt), 0))
+    hdopb = int(float(hdop) * 10)
+
+    payload.append(((latb >> 16) & 0xFF))
+    payload.append(((latb >> 8) & 0xFF))
+    payload.append((latb & 0xFF))
+    payload.append(((lonb >> 16) & 0xFF))
+    payload.append(((lonb >> 8) & 0xFF))
+    payload.append((lonb & 0xFF))
+    payload.append(((altb  >> 8) & 0xFF))
+    payload.append((altb & 0xFF))
+    payload.append(hdopb & 0xFF)
+    return payload
+
+# add logfile
+#logLevel=logging.DEBUG
+logLevel=logging.INFO
+#logging.basicConfig(filename="gps.log", format='%(asctime)s - %(funcName)s - %(lineno)d - %(levelname)s - %(message)s', level=logLevel)
+
+# create a Dragino object and join to TTN
+D = Dragino("dragino.toml", logging_level=logLevel, enableGPS=True)
+D.join()
+
+print("Waiting for JOIN ACCEPT")
+while not D.registered():
+    print(".",end="")
+    sleep(2)
+print("\nJoined")
+
+#while gps.lat is None:
+while gps.hdop is None:
+   print("Waiting for valid SKY [hdop - Horizontal Dilution of Precision] value",gps.lat, gps.lon, gps.alt, gps.hdop)
+   sleep(1)
+
+for i in range(0, 50):
+    sent=convert_payload(gps.lat, gps.lon, gps.alt, gps.hdop)
+    D.send_bytes(sent)
+    print(sent)
+    print(gps.lat, gps.lon, gps.alt, gps.hdop)
+    sleep(5)
+    start = datetime.utcnow()
+    while D.transmitting:
+        pass
+    end = datetime.utcnow()
+    print("Sent GPS Co-Ordinates (TTN Mapper) message ({})".format(end-start))
+    sleep(295)
+#    sleep(99*D.lastAirTime()) # limit to 1% duty cycle


### PR DESCRIPTION
Included are a reference python CayenneLLP and TTNMapper compliant GPS tracker/transmitter.

CayenneLLP just sends Latitude, Longitude and Altitude - which is acceptable to TTNMapper however they ideally like to have a HDOP (Horizontal Dilution of Precision) reference for positional accuracy. To achieve this the GPShandler.py has been modified to include SKY objects as well as the TPV (Time Position Velocity) Object.